### PR TITLE
Fix memory leak in parse_structured_data_element

### DIFF
--- a/src/syslog.c
+++ b/src/syslog.c
@@ -173,7 +173,7 @@ int parse_context_get_structured_data_elements(syslog_parse_context_t * ctx, cha
 
 syslog_parse_context_t create_parse_context(const char* raw_message) {
   // Pointer should automatically be initialized to 0
-  syslog_parse_context_t ctx = { raw_message, 0, 0 >= strlen(raw_message) };
+  syslog_parse_context_t ctx = { raw_message, 0, 0 == strlen(raw_message) };
   return ctx;
 }
 

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -187,6 +187,7 @@ int parse_structured_data_element(char* data_string, syslog_extended_property_t 
   // SD-ID
   int id_length = parse_context_next_until_with_escapes(&ctx, SEPARATOR, &element_string[intern_pointer], 1, 1);
   if (!id_length) {
+    free(element_string);
     return 0;
   }
 


### PR DESCRIPTION
- Fix memory leak in `parse_structured_data_element`
  `element_string` is alloc'd with `calloc`, but if `parse_structured_data_element` encounters the condition `!id_length`, the function exits without freeing `element_string`.
- Remove redundant unsigned int < 0 check
  `size_t` is unsigned, no need to check if it is less than 0

Verified tests pass, tested with structured data missing SD-ID to hit condition where `free` call was added.